### PR TITLE
server/play: Use golang.org/x/net/context/ctxhttp package

### DIFF
--- a/server/play/get.go
+++ b/server/play/get.go
@@ -15,7 +15,7 @@ import (
 	"github.com/dave/services/getter/get"
 	"github.com/dave/services/getter/gettermsg"
 	"github.com/dave/services/session"
-	"github.com/shurcooL/go/ctxhttp"
+	"golang.org/x/net/context/ctxhttp"
 	"gopkg.in/src-d/go-billy.v4"
 )
 


### PR DESCRIPTION
The issue golang/go#21358 has been resolved upstream, so there's no more need to use a temporary fork of the `ctxhttp` package.

Also, [`github.com/shurcooL/go/ctxhttp`](https://godoc.org/github.com/shurcooL/go/ctxhttp) has been deprecated and will be deleted on 2018-12-01, see shurcooL/go@58262d155ee0c659f3e3963bfccbac0f6a6a1d2b.

/cc @dave